### PR TITLE
Remove content-length header if there's no body

### DIFF
--- a/dio/lib/src/dio.dart
+++ b/dio/lib/src/dio.dart
@@ -1042,8 +1042,10 @@ abstract class DioMixin implements Dio {
         });
       }
       return byteStream;
-    }else{
+    } else {
       options.headers.remove(Headers.contentTypeHeader);
+      options.headers.remove(Headers.contentLengthHeader);
+
     }
     return null;
   }


### PR DESCRIPTION
We were only removing the content-type header previously, but this would cause an error

### New Pull Request Checklist

- [X] I have read the [Documentation](https://pub.dartlang.org/packages/dio)
- [X] I have searched for a similar pull request in the [project](https://github.com/flutterchina/dio/pulls) and found none
- [X] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests and they pass

This merge request fixes / refers to the following issues: ...
https://github.com/flutterchina/dio/issues/891
### Pull Request Description

...

